### PR TITLE
Correctly close native applications.

### DIFF
--- a/Src/remote/ApplicationProcessManager.cpp
+++ b/Src/remote/ApplicationProcessManager.cpp
@@ -56,7 +56,6 @@ void NativeApplication::onTerminationTimeoutReached()
 void NativeApplication::onProcessFinished(int exitCode, QProcess::ExitStatus exitStatus)
 {
     mProcess->close();
-    delete mProcess;
 
     Q_EMIT finished();
 }


### PR DESCRIPTION
Bug #529.
mProcess deletion is handled in NativeApplication destructor.
Signed-off-by: Nikolay Nizov nizovn@gmail.com
