### PR TITLE
BootManager: switch back to startup when compositor is gone

### DIFF
--- a/Src/base/BootManager.h
+++ b/Src/base/BootManager.h
@@ -71,6 +71,9 @@ class BootStateStartup : public BootStateBase
 public:
     virtual void enter();
 	virtual void handleEvent(BootEvent event);
+
+private:
+	void advanceState();
 };
 
 class BootStateFirstUse : public BootStateBase


### PR DESCRIPTION
Rather than cycling within the normal state when the compositor goes away switch back to
startup to correctly perform all needed actions again when the compositor comes back.

Signed-off-by: Simon Busch morphis@gravedo.de
