### PR TITLE
Run app-install even though we don't have a proper cryptofs setup

### DIFF
--- a/Src/base/application/ApplicationManager.cpp
+++ b/Src/base/application/ApplicationManager.cpp
@@ -186,7 +186,10 @@ void ApplicationManager::runAppInstallScripts()
 	int ret;
 
 	cmd = "mountcfs";
-	ret = ::system(cmd.c_str());
+	
+	//FIXME: We currently don't have a real cryptofs, but the mount does exist. We therefore want to execute app-install, we therefore set ret to 0 untill we have a proper cryptofs setup. 
+	ret = 0;
+	//ret = ::system(cmd.c_str());
 
 	if (ret == 0) {
 		g_warning("Running app install script");


### PR DESCRIPTION
Works around:

Sep 21 22:08:25 qemux86 LunaAppManager[490]: sh: mountcfs: command not
found
Sep 21 22:08:25 qemux86 LunaAppManager[490]: **
(LunaAppManager:490): WARNING **: cryptofs could not be mounted. Not
running app-install script

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>