### PR TITLE
Run configurator for Activities after First Use & Local Profile creation

### DIFF
--- a/Src/base/BootManager.h
+++ b/Src/base/BootManager.h
@@ -1,6 +1,7 @@
 /* @@@LICENSE
 *
 * Copyright (c) 2013 Simon Busch
+* Copyright (c) 2016 Herman van Hazendonk <github.com@herrie.org>
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -36,6 +37,7 @@ enum BootState {
 
 enum BootEvent {
 	BOOT_EVENT_FIRST_USE_DONE,
+	BOOT_EVENT_PROFILE_CREATED,
 	BOOT_EVENT_COMPOSITOR_AVAILABLE,
 	BOOT_EVENT_COMPOSITOR_NOT_AVAILABLE,
 	BOOT_EVENT_WEBAPPMGR_AVAILABLE,
@@ -92,8 +94,10 @@ private:
 private:
 	void launchFirstUseApp();
 	void createLocalAccount();
+	void runConfigurator();
 
 	static bool cbCreateLocalAccount(LSHandle *handle, LSMessage *message, void *user_data);
+	static bool cbRunConfigurator(LSHandle *handle, LSMessage *message, void *user_data);
 };
 
 class BootStateNormal : public BootStateBase


### PR DESCRIPTION
This should solve the missing activities after First Use is run (http://issues.webos-ports.org/issues/865), since we're replicating the luna-send call to create the activities after First Use has run and Local Profile was created, just like Upstart did previously: https://github.com/openwebos/configurator/blob/18ebce9af19d635b9c8765c7165d2ac2e7b007d0/desktop-support/configurator.upstart#L50

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>

