### PR TITLE
Pass correct parameters for clearMemoryCaches call

### DIFF
--- a/Src/remote/WebAppMgrProxy.cpp
+++ b/Src/remote/WebAppMgrProxy.cpp
@@ -460,7 +460,7 @@ void WebAppMgrProxy::clearMemoryCaches()
     }
 
     if (!LSCallOneReply(mService, "luna://org.webosports.webappmanager/clearMemoryCaches",
-                        "", NULL, NULL, NULL, &lserror)) {
+                        "{}", NULL, NULL, NULL, &lserror)) {
         g_warning("Failed to clear memory caches: %s", lserror.message);
         LSErrorFree(&lserror);
     }


### PR DESCRIPTION
Fixes:

Oct 04 14:02:57 qemux86 LunaAppManager[660]: [] [pmlog] <default>
LS_INVALID_PAYLOAD {"FILE":"callmap.c","LINE":2034} Empty payload is not
valid JSON. Use {}
(LunaAppManager:660): WARNING **: Failed to clear memory caches: Empty
payload is not valid JSON. Use {}

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>