### PR TITLE
[Qt 5.12] launchProcess: set QT_QPA_PLATFORM value

### DIFF
--- a/Src/remote/ApplicationProcessManager.cpp
+++ b/Src/remote/ApplicationProcessManager.cpp
@@ -286,7 +286,7 @@ qint64 ApplicationProcessManager::launchProcess(const QString& id, const QString
 
     QProcessEnvironment environment = QProcessEnvironment::systemEnvironment();
     environment.insert("XDG_RUNTIME_DIR","/tmp/luna-session");
-    environment.insert("QT_WAYLAND_DISABLE_WINDOWDECORATION", "1");
+    environment.insert("QT_QPA_PLATFORM", "wayland");
     environment.insert("QT_IM_MODULE", "Maliit");
     environment.insert("SDL_VIDEODRIVER", "wayland");
 


### PR DESCRIPTION
This is necessary on qemu platform, as the swrast EGL driver
doesn't provide all the expected extension and confuses Qt
as to which driver to use here.

Also, stop setting QT_WAYLAND_DISABLE_WINDOWDECORATION as it
is now deprecated in Qt 5.12. Use XdgShell extension instead.