### PR TITLE
luna-appmanager.perm.json: Set correct permissions

### DIFF
--- a/files/sysbus/luna-appmanager.perm.json
+++ b/files/sysbus/luna-appmanager.perm.json
@@ -1,19 +1,8 @@
 {
     "luna-appmanager": [ 
-        "all",
-        "appinstalld.internal",
-        "applications.internal",
-        "devices",
-        "database.internal",
-        "hub.configuration",
-        "launcher.control",
-        "launcher.status",
-        "networking.internal",
-        "notifications",
-        "security",
-        "settings",
-        "system",
-        "system.debug"
+        "all"
+    ],
+    "org.webosports.bootmgr": [ 
+        "applications.internal"
     ]
 }
-


### PR DESCRIPTION
luna-appmanager tag had duplicate entries due to "all" already covering the other. Removing the unnecessary bits.

"org.webosports.bootmgr" tag was missing, causing the "Open webOS"-account not to be created and FirstUse state to not complete.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>