### PR TITLE
luna-appmanager.perm.json: Add missing permissions

### DIFF
--- a/files/sysbus/luna-appmanager.perm.json
+++ b/files/sysbus/luna-appmanager.perm.json
@@ -3,6 +3,8 @@
         "all"
     ],
     "org.webosports.bootmgr": [ 
-        "applications.internal"
+        "applications",
+        "applications.internal",
+        "database.internal"
     ]
 }


### PR DESCRIPTION
Solves:

2020-06-23T12:33:25.199951Z [51.936090689] user.warning configurator [] <default-lib> LS_REQUIRES_SECURITY {"SERVICE":"org.webosports.bootmgr","CATEGORY":"/","METHOD":"run"} Service security groups don't allow method call.

Fixes permissions to:

if (!LSCall(m_service, "palm://com.palm.display/control/setProperty",

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>