### PR TITLE
Fix build with gcc-11

### DIFF
--- a/Src/base/application/ApplicationManagerService.cpp
+++ b/Src/base/application/ApplicationManagerService.cpp
@@ -349,7 +349,7 @@ static bool servicecallback_close( LSHandle* lshandle, LSMessage *message,
 	processid = json_object_object_get(root,"processId");
 	if(processid) {
 		qint64 processId = (qint64) atol(json_object_get_string(processid));
-		if (processid > 0) {
+		if (processId > 0) {
 			ApplicationProcessManager::instance()->killByProcessId(processId);
 			// FIXME: $$$ this was now made asynchronous, so we can't find out if the call succeeded or failed.
 			success = true;


### PR DESCRIPTION
* https://gcc.gnu.org/gcc-11/porting_to.html
  Ordered pointer comparison with integer
  GCC 11 now issues a diagnostic for ordered comparisons of pointers against constant integers. Commonly this is an ordered comparison against NULL or 0. These should be equality comparisons, not ordered comparisons.

* fixes:
/OE/build/luneos-honister/webos-ports/tmp-glibc/work/core2-64-webos-linux/luna-appmanager/1.0.0-22+gitAUTOINC+0dee1323e6-r0/git/Src/base/application/ApplicationManagerService.cpp: In function 'bool servicecallback_close(LSHandle*, LSMessage*, void*)':
/OE/build/luneos-honister/webos-ports/tmp-glibc/work/core2-64-webos-linux/luna-appmanager/1.0.0-22+gitAUTOINC+0dee1323e6-r0/git/Src/base/application/ApplicationManagerService.cpp:352:31: error: ordered comparison of pointer with integer zero ('json_object*' and 'int')
  352 |                 if (processid > 0) {
      |                     ~~~~~~~~~~^~~

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>