### PR TITLE
luna-appmanager.perm.json: Add com.palm.applicationManager

### DIFF
--- a/files/sysbus/luna-appmanager.perm.json
+++ b/files/sysbus/luna-appmanager.perm.json
@@ -2,6 +2,9 @@
     "luna-appmanager": [ 
         "all"
     ],
+    "com.palm.applicationManager": [ 
+        "all"
+    ],
     "org.webosports.bootmgr": [ 
         "applications",
         "applications.internal",


### PR DESCRIPTION
Fixes:

Nov 03 13:05:22 qemux86-64 luna-next[388]: [] [pmlog] <default-lib> LS_REQUIRES_SECURITY {"SERVICE":"com.palm.applicationManager","CATEGORY":"/","METHOD":"focusApplication"} Service security groups don't allow method call.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>