### PR TITLE
BootManager: don't start systemui and launcher

### DIFF
--- a/Src/base/BootManager.cpp
+++ b/Src/base/BootManager.cpp
@@ -292,8 +292,6 @@ void BootStateNormal::activateSuspend(bool enable)
 
 void BootStateNormal::launchBootTimeApps()
 {
-	ApplicationProcessManager::instance()->launch("com.palm.launcher", "{\"launchedAtBoot\":true}");
-	ApplicationProcessManager::instance()->launch("com.palm.systemui", "{\"launchedAtBoot\":true}");
 	ApplicationManager::instance()->launchBootTimeApps();
 }
 


### PR DESCRIPTION
They will be started by OSE's bootd service

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>