### PR TITLE
luna-appmanager: Add ACG groups file

### DIFF
--- a/files/sysbus/luna-appmanager.groups.json
+++ b/files/sysbus/luna-appmanager.groups.json
@@ -1,0 +1,4 @@
+{
+ "allowedNames": ["com.palm.appinstaller", "com.palm.applicationManager", "com.palm.eventreporter.LunaAppManager", "org.webosports.bootmgr", "com.palm.applicationManager-webappmgr", "com.palm.systemmanager-prefs-*", "com.palm.systemmanager-localeprefs-*", "org.webosports.bootmgr-displayblocker"],
+ "appmanager.management": ["dev"]
+}


### PR DESCRIPTION
Fixes:

WARNING: luneos-dev-image-1.0-r0 do_validate_ls2_acg: Found 34 group(s) that appear only in api-permissions.d, consider define them in groups.d
WARNING: luneos-dev-image-1.0-r0 do_validate_ls2_acg: === LIST BEGIN: Groups used in api-permissions.d but not defined in groups.d ===
WARNING: luneos-dev-image-1.0-r0 do_validate_ls2_acg:   appmanager.management