### PR TITLE
luna-appmanager: Fix LS2 permission issues

### DIFF
--- a/files/sysbus/luna-appmanager.perm.json
+++ b/files/sysbus/luna-appmanager.perm.json
@@ -40,6 +40,9 @@
         "wifi.query",
         "wifi.management"
     ],
+    "com.palm.eventreporter.LunaAppManager": [
+        "database.operation"
+    ]
     "org.webosports.bootmgr-displayblocker": [
         "luna-sysmgr.operation"
     ]


### PR DESCRIPTION
When doing a rescan of the apps getting the following error leading to new apps not being added to the launcher.

Apr 16 14:06:52 qemux86-64 mojodb-luna[536]: [] [pmlog] <default-lib> LS_REQUIRES_SECURITY {"CLIENT":"com.palm.eventreporter.LunaAppManager","SERVICE":"com.palm.db","CATEGORY":"/","METHOD":"put"} Service security groups don't allow method call.

Seems to be originating from https://github.com/webOS-ports/luna-appmanager/blob/243783ba25b638d096640414a880afd204157caf/Src/base/application/ApplicationManager.cpp#L352

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
